### PR TITLE
chore: add submodules and gomodtidy to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,8 @@
     "config:best-practices",
     "security:openssf-scorecard",
     "helpers:pinGitHubActionDigests",
-    ":rebaseStalePrs"
+    ":rebaseStalePrs",
+    ":enableVulnerabilityAlert"
   ],
   "git-submodules": {
     "enabled": true

--- a/renovate.json
+++ b/renovate.json
@@ -7,16 +7,10 @@
     "helpers:pinGitHubActionDigests",
     ":rebaseStalePrs"
   ],
-  "customManagers": [
-    {
-      "description": "Task tools",
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/tasks_tools\\.yaml/"
-      ],
-      "matchStrings": [
-        "# renovate: datasource=(?<datasource>[a-z-.]+?) depName=(?<depName>[^\\s]+?)(?: (lookupName|packageName)=(?<packageName>[^\\s]+?))?(?: versioning=(?<versioning>[^\\s]+?))?(?: extractVersion=(?<extractVersion>[^\\s]+?))?(?: registryUrl=(?<registryUrl>[^\\s]+?))?\\s.+?default \"(?<currentValue>.+?)\"\\s"
-      ]
-    }
+  "git-submodules": {
+    "enabled": true
+  },
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Updates the renovate config which has been copied from the wrong source [build module renovate.json](https://github.com/openmcp-project/build/blob/main/renovate.json)

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
None

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```
