### PR TITLE
fix: workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -3,6 +3,9 @@ name: E2E Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e:
     name: E2E Tests


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix for [https://github.com/openmcp-project/service-provider-velero/security/code-scanning/2](https://github.com/openmcp-project/service-provider-velero/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.  
Best single change (without altering functionality) is to set workflow-level permissions to read-only for repository contents, which satisfies checkout/test use and CodeQL’s recommendation.

**File to edit:** `.github/workflows/go.yaml`  
**Change location:** after the `on:` trigger block and before `jobs:`  
**Change to add:**
```yaml
permissions:
  contents: read
```

No imports, methods, or definitions are needed (YAML workflow config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

**Which issue(s) this PR fixes**:
[https://github.com/openmcp-project/service-provider-velero/security/code-scanning/2](https://github.com/openmcp-project/service-provider-velero/security/code-scanning/2)

**Special notes for your reviewer**:
Generated by Copilot Autofix.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
NONE
```

