### PR TITLE
fix(deps): update controller-utils to v0.27.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/openmcp-project/service-provider-velero
 go 1.26.1
 
 require (
-	github.com/openmcp-project/controller-utils v0.27.0
+	github.com/openmcp-project/controller-utils v0.27.1
 	github.com/openmcp-project/openmcp-operator/api v0.18.1
 	github.com/openmcp-project/openmcp-operator/lib v0.18.1
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -129,8 +129,8 @@ github.com/onsi/ginkgo/v2 v2.28.1 h1:S4hj+HbZp40fNKuLUQOYLDgZLwNUVn19N3Atb98NCyI
 github.com/onsi/ginkgo/v2 v2.28.1/go.mod h1:CLtbVInNckU3/+gC8LzkGUb9oF+e8W8TdUsxPwvdOgE=
 github.com/onsi/gomega v1.39.1 h1:1IJLAad4zjPn2PsnhH70V4DKRFlrCzGBNrNaru+Vf28=
 github.com/onsi/gomega v1.39.1/go.mod h1:hL6yVALoTOxeWudERyfppUcZXjMwIMLnuSfruD2lcfg=
-github.com/openmcp-project/controller-utils v0.27.0 h1:sMCYBGJPYW17aW9J5nUKS6QsDjOAGxxVmURynNCOCy8=
-github.com/openmcp-project/controller-utils v0.27.0/go.mod h1:rdJ+nlSZbpTrTL1SR2PfZa7IE47Ifs05Vhu5QmRFagc=
+github.com/openmcp-project/controller-utils v0.27.1 h1:eMxmyS59+XQALX0uwg5t1GeasSbzWWj1KvzIq8BTE2A=
+github.com/openmcp-project/controller-utils v0.27.1/go.mod h1:xK6o4ZYsGUTW7BI/iDFiaxbRQD5gp8vAtkO0X2VIG5s=
 github.com/openmcp-project/openmcp-operator/api v0.18.1 h1:jBc0b8FxgDZR+8l+wkrLaCj/h31RYJTkdio+yIHH8hU=
 github.com/openmcp-project/openmcp-operator/api v0.18.1/go.mod h1:eI3caa7YYHXV3eD0BD/vfQLb2epxOBRgdDK4T2xr12w=
 github.com/openmcp-project/openmcp-operator/lib v0.18.1 h1:9B/akEJ5yw1GmrVq0bAPeawoO6wzWXSvDjOXDuNOkrk=

--- a/pkg/secret/secret_test.go
+++ b/pkg/secret/secret_test.go
@@ -93,6 +93,7 @@ func TestConfigure(t *testing.T) {
 					assert.NoError(t, tt.platformCluster.Client().Get(context.TODO(), client.ObjectKeyFromObject(sourceSecret), sourceSecret))
 					assert.NoError(t, tt.workloadCluster.GetClient().Get(context.TODO(), client.ObjectKeyFromObject(targetSecret), targetSecret))
 					assert.Equal(t, sourceSecret.Data, targetSecret.Data)
+					assert.Equal(t, corev1.SecretTypeDockerConfigJson, targetSecret.Type, "secret type should be preserved")
 				}
 			}
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
Updates controller-utils to v0.27.1 which fixes SecretMutator.Mutate() to correctly set the Type field on secrets.

**Which issue(s) this PR fixes**:
Fixes secret type handling for OCI registry pull secrets.

**Special notes for your reviewer**:
N/A

**Release note**:
```bugfix user
Updated controller-utils to v0.27.1 fixing secret type handling.
```