### PR TITLE
chore: renovate groups all openmcp-project updates in one PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,11 +16,6 @@
   ],
   "packageRules": [
     {
-      "description": "Automerge submodule update",
-      "automerge": true,
-      "matchPackageNames": ["hack/common"]
-    },
-    {
       "description": "Group openmcp-project/build submodule and workflow updates",
       "matchDepNames": [
         "hack/common",

--- a/renovate.json
+++ b/renovate.json
@@ -16,12 +16,35 @@
   ],
   "packageRules": [
     {
+      "description": "Automerge submodule update",
+      "automerge": true,
+      "matchPackageNames": ["hack/common"]
+    },
+    {
       "description": "Group openmcp-project/build submodule and workflow updates",
       "matchDepNames": [
         "hack/common",
         "openmcp-project/build"
       ],
       "groupName": "openmcp-project/build"
+    },
+    {
+      "description": "Update and automerge all components from openmcp-project immediately in one singe PR",
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "openmcp-project Go dependencies",
+      "groupSlug": "openmcp-go-deps",
+      "automerge": true,
+      "automergeType": "pr",
+      "prPriority": 10,
+      "semanticCommitType": "chore",
+      "rebaseWhen": "auto",
+      "minimumReleaseAge": "0 days",
+      "enabled": true,
+      "matchPackageNames": [
+        "/^github.com/openmcp-project//"
+      ]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,7 @@
       "groupName": "openmcp-project/build"
     },
     {
-      "description": "Update and automerge all components from openmcp-project immediately in one singe PR",
+      "description": "Update and automerge all components from openmcp-project immediately in one single PR",
       "matchManagers": [
         "gomod"
       ],


### PR DESCRIPTION
**What this PR does / why we need it**:

Renovate will put all changes from openmcp-project into one single PR, current open for example:

- https://github.com/openmcp-project/service-provider-velero/pull/65 
- https://github.com/openmcp-project/service-provider-velero/pull/61 
- https://github.com/openmcp-project/service-provider-velero/pull/56 
- https://github.com/openmcp-project/service-provider-velero/pull/55 
- https://github.com/openmcp-project/service-provider-velero/pull/53 
- https://github.com/openmcp-project/service-provider-velero/pull/44 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency

```
