### PR TITLE
chore(deps): fix renovate for openmcp-project deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "git-submodules": {
+    "enabled": true
+  },
+  "gitIgnoredAuthors": [
+    "github-actions[bot]@users.noreply.github.com"
+  ],
   "extends": [
     "config:recommended",
     "config:best-practices",
@@ -8,9 +14,6 @@
     ":rebaseStalePrs",
     ":enableVulnerabilityAlerts"
   ],
-  "git-submodules": {
-    "enabled": true
-  },
   "postUpdateOptions": [
     "gomodTidy"
   ],
@@ -30,30 +33,37 @@
   ],
   "packageRules": [
     {
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "matchDepTypes": [
+        "golang"
+      ],
+      "rangeStrategy": "bump"
+    },
+    {
+      "description": "Group openmcp-project Go components",
+      "matchManagers": [
+        "gomod"
+      ],
+      "matchPackageNames": [
+        "github.com/openmcp-project/*",
+        "openmcp-project/*"
+      ],
+      "groupName": "openmcp-project Go dependencies",
+      "minimumReleaseAge": "0 days",
+      "automerge": true
+    },
+    {
       "description": "Group openmcp-project/build submodule and workflow updates",
       "matchDepNames": [
         "hack/common",
         "openmcp-project/build"
       ],
       "groupName": "openmcp-project/build"
-    },
-    {
-      "description": "Update and automerge all components from openmcp-project immediately in one single PR",
-      "matchManagers": [
-        "gomod"
-      ],
-      "groupName": "openmcp-project Go dependencies",
-      "groupSlug": "openmcp-go-deps",
-      "automerge": true,
-      "automergeType": "pr",
-      "prPriority": 10,
-      "semanticCommitType": "chore",
-      "rebaseWhen": "auto",
-      "minimumReleaseAge": "0 days",
-      "enabled": true,
-      "matchPackageNames": [
-        "/^github.com/openmcp-project//"
-      ]
     }
   ]
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Section "Group openmcp-project/build submodule and workflow updates" was just moved to the end to align with renovate.json from other repositories.
Looks ugly in diff, but this renovate.json ist mostly the same than in [service-provider-crossplane](github.com/openmcp-project/service-provider-crossplane/renovate.json) or [platform-service-test-runner](github.com/openmcp-project/platform-service-test-runner/renovate.json)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency

```
