### PR TITLE
fix: local debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ spec:
 
 See the [OpenControlPlane Quality Criteria](https://open-control-plane.io/developers/serviceprovider/quality-criteria) for definitions.
 
+## Local Debugging Limitations
+
+Note that when [running the controller locally](https://open-control-plane.io/developers/serviceprovider/debugging#running-your-controller-locally) you need to temporarily patch the managed service account setup of package `authn` for the deployment on the workload cluster to become ready. Otherwise velero won't be able to connect to the control plane that it watches.
+
 ## 🤝 Support, Feedback, Contributing
 
 This project is open to feature requests/suggestions, bug reports etc. via [GitHub issues](https://github.com/openmcp-project/service-provider-velero/issues). Contribution and feedback are encouraged and always welcome. For more information about how to contribute, the project structure, as well as additional contribution information, see our [Contribution Guidelines](CONTRIBUTING.md).

--- a/cmd/service-provider-velero/main.go
+++ b/cmd/service-provider-velero/main.go
@@ -314,6 +314,17 @@ func main() {
 		setupLog.Error(err, "unable to add platform cluster to manager")
 		os.Exit(1)
 	}
+
+	clusterAccessReconciler := clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "velero").
+		WithMCPScheme(mcpScheme).
+		WithWorkloadScheme(workloadScheme).
+		WithRetryInterval(10 * time.Second).
+		WithMCPPermissions(mcpPermissions()).
+		WithWorkloadPermissions(workloadPermissions())
+	if debugEnabled() {
+		clusterAccessReconciler = localaccess.NewLocalAccessReconciler(clusterAccessReconciler)
+	}
+
 	spr := serviceprovider.NewAPIReconcilerBuilder[*velerosv1alpha1.Velero, *velerosv1alpha1.ProviderConfig]().
 		EmptyObjectProvider(func() *velerosv1alpha1.Velero { return &velerosv1alpha1.Velero{} }).
 		EmptyConfigProvider(func() *velerosv1alpha1.ProviderConfig { return &velerosv1alpha1.ProviderConfig{} }).
@@ -328,12 +339,7 @@ func main() {
 				return resources.NewManager(instance.GetID(obj))
 			},
 		}).
-		ClusterAccessReconciler(clusteraccess.NewClusterAccessReconciler(platformCluster.Client(), "velero").
-			WithMCPScheme(mcpScheme).
-			WithWorkloadScheme(workloadScheme).
-			WithRetryInterval(10 * time.Second).
-			WithMCPPermissions(mcpPermissions()).
-			WithWorkloadPermissions(workloadPermissions())).
+		ClusterAccessReconciler(clusterAccessReconciler).
 		MustBuild()
 	if err := spr.SetupWithManager(mgr, "velero"); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "Velero")
@@ -385,7 +391,7 @@ func requestOnboardingClusterAccess(ctx context.Context, mgr clusteraccess.Manag
 func patchOnboardingClient(ctx context.Context, platformCluster *clusters.Cluster, onboardingCluster *clusters.Cluster, cmdSuffix string) (*clusters.Cluster, error) {
 	onboardingAr := &clustersv1alpha1.AccessRequest{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      clusteraccess.StableRequestNameFromLocalName("fooservice.foo.services.open-control-plane.io", cmdSuffix),
+			Name:      clusteraccess.StableRequestNameFromLocalName("velero.velero.services.openmcp.cloud", cmdSuffix),
 			Namespace: os.Getenv("POD_NAMESPACE"),
 		},
 	}


### PR DESCRIPTION
On-behalf-of: @SAP christopher.junk@sap.com

**What this PR does / why we need it**:
Fixes the local access setup. I added a hint in the readme regarding a known limitation/caveat for locally running sp-velero. Reason for this is that sp-velero sets up a velero deployment on the workload cluster to watch a control plane cluster. When starting the controller with DEV_DEBUG=1, the control plane client gets patched which is then propagated to the workload cluster deployment instead of the incluster/kind resolvable ip.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
We could implement a reusable mechanism that allows to distinguish between local ip client and incluster clients to fix this situation for any service provider that deploys its workload on a workload cluster.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
fix cluster access for local debugging
```
